### PR TITLE
Introduce docker-compose

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,1 @@
+KUBECONFIG_DIRECTORY=~/.kube

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.3'
+services:
+  api:
+    container_name: api
+    hostname: api
+    image: python:3
+    restart: always
+    environment:
+      FLASK_APP: "main.py"
+    working_dir: /usr/src/app
+    command: |
+      bash -c "pip install --no-cache-dir -r ./requirements.txt && python -m flask run -h 0.0.0.0"
+    environment:
+      FLASK_APP: "main.py"
+      FLASK_DEBUG: "1"
+    ports:
+      - '8081:5000'
+    expose:
+      - '5000'
+    networks:
+      default:
+        aliases:
+          - api
+    volumes:
+      - type: bind
+        source: ./gaas-api
+        target: /usr/src/app/
+      - type: bind
+        source: "${KUBECONFIG_DIRECTORY}"
+        target: /root/.kube/
+  portal:
+    container_name: portal
+    image: nginx:alpine
+    depends_on:
+      - api
+    ports:
+      - '8080:80'
+    volumes:
+      - type: bind
+        source: ./gaas-portal/nginx
+        target: /etc/nginx/conf.d/
+      - type: bind
+        source: ./gaas-portal/static
+        target: /usr/share/nginx/html/


### PR DESCRIPTION
It does not depend on docker building, but instead installs the requirements.txt on startup, and relies on Flask to reload python files on subsequent code changes.

Has been tested to the point where it could deploy and delete Teeworlds on the FFA cluster.

Comments much appreciated.

After `docker-compose up -d`
localhost:8080 for portal
localhost:8081 for api